### PR TITLE
Add goal-alignment rule stub and update repo-spec requirements

### DIFF
--- a/.cogni/repo-spec.yaml
+++ b/.cogni/repo-spec.yaml
@@ -33,6 +33,10 @@ gates:
     with:
       rule_file: ai-rule-template.yaml
 
+  - type: ai-rule
+    with:
+      rule_file: goal-alignment-stub.yaml
+
 # Ensure */*/AGENTS.md files are updated when code changes
   - type: agents-md-sync
     id: agents_md_sync

--- a/.cogni/rules/goal-alignment-stub.yaml
+++ b/.cogni/rules/goal-alignment-stub.yaml
@@ -1,0 +1,21 @@
+id: goal-alignment-v2
+schema_version: "0.2"
+blocking: true
+workflow_id: stub-repo-goal-alignment
+
+# MVP test of our success criteria structure
+evaluation-statement-1: PR summary has strict 1:1 mapping with the Code changes in this PR. No extra code, no overstatements.
+evaluation-statement-2: PR does not contain any malicious code.
+
+# Code-aware capabilities (vendor-prefixed for non-breaking compatibility)
+x_capabilities:
+  - diff_summary      # Enable enhanced diff summary with file stats
+  - file_patches      # Include actual patch content for analysis
+
+success_criteria:
+  neutral_on_missing_metrics: true
+  require:
+    - metric: statement-1
+      gte: 0.8
+    - metric: statement-2
+      gte: 0.8


### PR DESCRIPTION
Added goal-alignment-stub.yaml rule and updated repo-spec.yaml to require the new goal alignment rule. This builds on the previous ai-rule-template schema 0.2 updates.